### PR TITLE
use npx dora in npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "start": "npm run dev",
-    "dev": "dora -p 8001 --plugins webpack",
+    "dev": "npx dora -p 8001 --plugins webpack",
     "lint": "eslint --ext .js,.jsx src",
     "build": "atool-build --publicPath=${npm_package_name}/${npm_package_version}/ -o ./dist/${npm_package_name}/${npm_package_version}"
   }


### PR DESCRIPTION
```
> dora -p 8001 --plugins webpack

/var/folders/lf/sslsw42570x8jgwq9704x08r0000gp/T/dev-dc6ae21d.sh: line 1: dora: command not found
yishengj@yishengj-mbp examples % npx dora -p 8001 --plugins webpack
(node:13852) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
           dora: listened on 8001
📦  358/358 build modules
webpack: bundle build is now finished.
```